### PR TITLE
Minimal support for wasm32-unknown-unknown

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,43 @@ const DEFAULT_INDEX_HTML: &'static str = r#"
 </html>
 "#;
 
+const DEFAULT_UNKNOWN_UNKNOWN_INDEX_HTML: &'static str = r#"
+<!DOCTYPE html>
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=1" name="viewport" />
+    <script>
+    var importObject = {'env': {
+        'js_raw_eval': function(pointer, length) {
+            if (window.instance === undefined) {
+                console.error("Callbacks during main() don't work for lack of access to the WASM instance, please move your code from `main` to `main_from_js`.");
+            }
+            var as_u8 = new Uint8Array(window.instance.exports.memory.buffer, pointer, length)
+            var decoder = new TextDecoder("UTF-8");
+            var s = decoder.decode(as_u8);
+            return eval(s);
+        },
+    }};
+
+    fetch("/main.wasm").then(response =>
+        response.arrayBuffer()
+    ).then(bytes =>
+        WebAssembly.instantiate(bytes, importObject)
+    ).then(results =>
+        {
+            window.instance = results.instance;
+
+            window.instance.exports.main_from_js()
+        }
+    );
+    </script>
+</head>
+<body>
+</body>
+</html>
+"#;
+
 const DEFAULT_TEST_INDEX_HTML: &'static str = r#"
 <!DOCTYPE html>
 <head>
@@ -928,7 +965,8 @@ fn command_test< 'a >( matches: &clap::ArgMatches< 'a >, project: &CargoProject 
 
 fn command_start< 'a >( matches: &clap::ArgMatches< 'a >, project: &CargoProject ) -> Result< (), Error > {
     let use_system_emscripten = matches.is_present( "use-system-emscripten" );
-    let targeting_webasm = matches.is_present( "target-webasm-emscripten" ) || matches.is_present( "target-webasm-unknown" );
+    let targeting_webasm_unknknown_unknown = matches.is_present( "target-webasm-unknown" );
+    let targeting_webasm = matches.is_present( "target-webasm-emscripten" ) || targeting_webasm_unknknown_unknown;
     let extra_path = if matches.is_present( "target-webasm-unknown" ) { None } else { check_for_emcc( use_system_emscripten, targeting_webasm ) };
 
     let build_matcher = BuildArgsMatcher {
@@ -1018,13 +1056,16 @@ fn command_start< 'a >( matches: &clap::ArgMatches< 'a >, project: &CargoProject
             if let Some( data ) = data {
                 rouille::Response::html( data )
             } else {
-                rouille::Response::html( DEFAULT_INDEX_HTML )
+                rouille::Response::html(if targeting_webasm_unknknown_unknown { DEFAULT_UNKNOWN_UNKNOWN_INDEX_HTML } else { DEFAULT_INDEX_HTML })
             }
         } else if url == "/js/app.js" {
             let data = outputs.lock().unwrap()[0].data.clone();
             rouille::Response::from_data( "application/javascript", data )
         } else if url == wasm_url {
             let data = outputs.lock().unwrap()[1].data.clone();
+            rouille::Response::from_data( "application/wasm", data )
+        } else if targeting_webasm_unknknown_unknown && url == "/main.wasm" {
+            let data = outputs.lock().unwrap()[0].data.clone();
             rouille::Response::from_data( "application/wasm", data )
         } else {
             rouille::Response::empty_404()

--- a/src/main.rs
+++ b/src/main.rs
@@ -578,7 +578,9 @@ impl< 'a > BuildArgsMatcher< 'a > {
     }
 
     fn triplet_or_default( &self ) -> &str {
-        if self.matches.is_present( "target-webasm-emscripten" ) {
+        if self.matches.is_present( "target-webasm-unknown") {
+            "wasm32-unknown-unknown"
+        } else if self.matches.is_present( "target-webasm-emscripten" ) {
             "wasm32-unknown-emscripten"
         } else {
             "asmjs-unknown-emscripten"
@@ -644,8 +646,8 @@ fn set_link_args( config: &Config ) {
 
 fn command_build< 'a >( matches: &clap::ArgMatches< 'a >, project: &CargoProject ) -> Result< (), Error > {
     let use_system_emscripten = matches.is_present( "use-system-emscripten" );
-    let targeting_webasm = matches.is_present( "target-webasm-emscripten" );
-    let extra_path = check_for_emcc( use_system_emscripten, targeting_webasm );
+    let targeting_webasm = matches.is_present( "target-webasm-emscripten" ) || matches.is_present( "target-webasm-unknown" );
+    let extra_path = if matches.is_present( "target-webasm-unknown" ) { None } else { check_for_emcc( use_system_emscripten, targeting_webasm ) };
 
     let build_matcher = BuildArgsMatcher {
         matches: matches,
@@ -926,8 +928,8 @@ fn command_test< 'a >( matches: &clap::ArgMatches< 'a >, project: &CargoProject 
 
 fn command_start< 'a >( matches: &clap::ArgMatches< 'a >, project: &CargoProject ) -> Result< (), Error > {
     let use_system_emscripten = matches.is_present( "use-system-emscripten" );
-    let targeting_webasm = matches.is_present( "target-webasm-emscripten" );
-    let extra_path = check_for_emcc( use_system_emscripten, targeting_webasm );
+    let targeting_webasm = matches.is_present( "target-webasm-emscripten" ) || matches.is_present( "target-webasm-unknown" );
+    let extra_path = if matches.is_present( "target-webasm-unknown" ) { None } else { check_for_emcc( use_system_emscripten, targeting_webasm ) };
 
     let build_matcher = BuildArgsMatcher {
         matches: matches,
@@ -1099,6 +1101,11 @@ fn main() {
                         .overrides_with( "target-asmjs-emscripten" )
                 )
                 .arg(
+                    Arg::with_name( "target-webasm-unknown" )
+                        .long( "target-webasm-unknown" )
+                        .help( "Generate webasm directly (wasm32-unknown-unknown, without Emscripten involvement)" )
+                )
+                .arg(
                     Arg::with_name( "package" )
                         .short( "p" )
                         .long( "package" )
@@ -1215,6 +1222,11 @@ fn main() {
                         .long( "target-webasm-emscripten" )
                         .help( "Generate webasm through Emscripten" )
                         .overrides_with( "target-asmjs-emscripten" )
+                )
+                .arg(
+                    Arg::with_name( "target-webasm-unknown" )
+                        .long( "target-webasm-unknown" )
+                        .help( "Generate webasm directly (wasm32-unknown-unknown, without Emscripten involvement)" )
                 )
                 .arg(
                     Arg::with_name( "package" )

--- a/src/main.rs
+++ b/src/main.rs
@@ -615,7 +615,7 @@ impl< 'a > BuildArgsMatcher< 'a > {
     }
 
     fn triplet_or_default( &self ) -> &str {
-        if self.matches.is_present( "target-webasm-unknown") {
+        if self.matches.is_present( "target-webasm") {
             "wasm32-unknown-unknown"
         } else if self.matches.is_present( "target-webasm-emscripten" ) {
             "wasm32-unknown-emscripten"
@@ -683,8 +683,8 @@ fn set_link_args( config: &Config ) {
 
 fn command_build< 'a >( matches: &clap::ArgMatches< 'a >, project: &CargoProject ) -> Result< (), Error > {
     let use_system_emscripten = matches.is_present( "use-system-emscripten" );
-    let targeting_webasm = matches.is_present( "target-webasm-emscripten" ) || matches.is_present( "target-webasm-unknown" );
-    let extra_path = if matches.is_present( "target-webasm-unknown" ) { None } else { check_for_emcc( use_system_emscripten, targeting_webasm ) };
+    let targeting_webasm = matches.is_present( "target-webasm-emscripten" ) || matches.is_present( "target-webasm" );
+    let extra_path = if matches.is_present( "target-webasm" ) { None } else { check_for_emcc( use_system_emscripten, targeting_webasm ) };
 
     let build_matcher = BuildArgsMatcher {
         matches: matches,
@@ -965,9 +965,9 @@ fn command_test< 'a >( matches: &clap::ArgMatches< 'a >, project: &CargoProject 
 
 fn command_start< 'a >( matches: &clap::ArgMatches< 'a >, project: &CargoProject ) -> Result< (), Error > {
     let use_system_emscripten = matches.is_present( "use-system-emscripten" );
-    let targeting_webasm_unknknown_unknown = matches.is_present( "target-webasm-unknown" );
+    let targeting_webasm_unknknown_unknown = matches.is_present( "target-webasm" );
     let targeting_webasm = matches.is_present( "target-webasm-emscripten" ) || targeting_webasm_unknknown_unknown;
-    let extra_path = if matches.is_present( "target-webasm-unknown" ) { None } else { check_for_emcc( use_system_emscripten, targeting_webasm ) };
+    let extra_path = if matches.is_present( "target-webasm" ) { None } else { check_for_emcc( use_system_emscripten, targeting_webasm ) };
 
     let build_matcher = BuildArgsMatcher {
         matches: matches,
@@ -1142,9 +1142,9 @@ fn main() {
                         .overrides_with( "target-asmjs-emscripten" )
                 )
                 .arg(
-                    Arg::with_name( "target-webasm-unknown" )
-                        .long( "target-webasm-unknown" )
-                        .help( "Generate webasm directly (wasm32-unknown-unknown, without Emscripten involvement)" )
+                    Arg::with_name( "target-webasm" )
+                        .long( "target-webasm" )
+                        .help( "HIGHLY EXPERIMENTAL: Generate webasm directly (wasm32-unknown-unknown, without Emscripten involvement)" )
                 )
                 .arg(
                     Arg::with_name( "package" )
@@ -1265,9 +1265,9 @@ fn main() {
                         .overrides_with( "target-asmjs-emscripten" )
                 )
                 .arg(
-                    Arg::with_name( "target-webasm-unknown" )
-                        .long( "target-webasm-unknown" )
-                        .help( "Generate webasm directly (wasm32-unknown-unknown, without Emscripten involvement)" )
+                    Arg::with_name( "target-webasm" )
+                        .long( "target-webasm" )
+                        .help( "HIGHLY EXPERIMENTAL: Generate webasm directly (wasm32-unknown-unknown, without Emscripten involvement)" )
                 )
                 .arg(
                     Arg::with_name( "package" )


### PR DESCRIPTION
This introduces the --target-webasm-unknown option which switches to building wasm32-unknown-unknown.

It's a crude patch as it only does the absolute minimum to be runnable with a hand-crafted index.html, but I hope it helps discovering which are the next steps.

One oddity that might be worth mentioning here is that as the compiler already outputs .wasm as the only result, and cargo-web looks for an additional s/.js/.wasm/ file, the WASM code is served both at /js/app.js and its $CRATE.wasm file name -- this can be confusing when one tries to use the default index.html, which loads /js/app.js as JavaScript and fails at parsing it. Shouldn't be too hard to describe whether the output is JS, WASM or both, and make the server serve accordingly (but it'd be too much restructuring for this first draft.)