### PR TITLE
fix detection of web workers as node.js runtime

### DIFF
--- a/src/wasm_runtime_standalone.js
+++ b/src/wasm_runtime_standalone.js
@@ -15,7 +15,7 @@ if( typeof Rust === "undefined" ) {
 }( this, function() {
     {{{loader}}}
 
-    if( typeof window === "undefined" ) {
+    if( typeof window === "undefined" && typeof process === "object" ) {
         const fs = require( "fs" );
         const path = require( "path" );
         const wasm_path = path.join( __dirname, "{{{wasm_filename}}}" );


### PR DESCRIPTION
When trying to use a wasm module and its javascript wrapper inside a web worker, the wrapper will call ```require( "fs" )``` and try to load the wasm module from a local file instead of loading it from the server. The wrapper wrongly assumes that the js code is being executed in a node.js runtime.

That is because when executing the wrapper in a web worker in the browser ```window``` is ```undefined```. 

Please merge this PR to enable using cargo web with web workers.
