### PR TITLE
Allow cargo-web to work with non-release builds on wasm32-unknown-unknown

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -481,14 +481,10 @@ impl Project {
         }
 
         let build_type = self.build_args.build_type;
-        let build_type = if self.backend().is_native_wasm() && build_type == BuildType::Debug {
+        if self.backend().is_native_wasm() && build_type == BuildType::Debug {
             // TODO: Remove this in the future.
-            eprintln!( "warning: debug builds on the wasm32-unknown-unknown are currently totally broken" );
-            eprintln!( "         forcing a release build" );
-            BuildType::Release
-        } else {
-            build_type
-        };
+            eprintln!( "warning: debug builds on the wasm32-unknown-unknown are potentially weird." );
+        }
 
         if !extra_emmaken_cflags.is_empty() {
             // We need to do this through EMMAKEN_CFLAGS since Rust can't handle linker args with spaces.

--- a/src/wasm_context.rs
+++ b/src/wasm_context.rs
@@ -957,6 +957,20 @@ impl Context {
         type_index
     }
 
+    
+    pub fn patch_code_by_index< F >( &mut self, mut callback: F ) where F: for <'r> FnMut( &'r u32, &'r mut Vec< Opcode > ) {
+        for (index, function) in self.functions.iter_mut() {
+            match function {
+                &mut FunctionKind::Definition { ref mut opcodes, .. } => {
+                    callback( index, opcodes );
+                },
+                _ => {}
+            }
+        }
+
+        // TODO: Other places where opcodes are used.
+    }
+
     pub fn patch_code< F >( &mut self, mut callback: F ) where F: for <'r> FnMut( &'r mut Vec< Opcode > ) {
         for function in self.functions.values_mut() {
             match function {


### PR DESCRIPTION
I saw #78, and decided to recompile without the flag. It led me down a rabbit hole. I didn't get any llvm errors (which was the bug) but it wasn't working correctly. Basically it seems like the optimized code looks a lot like:

    ...
    i32const (offset_for_js_function)
    call(function_index)
    ...

whereas the unoptimized code can look like:

    i32const (offset_for_js_function)
    setlocal(24)
    ....
    getlocal(24)
    call(function_index)

The existing code doesn't handle this case, because it assumes that the i32const instruction is immediately prior to the call instruction.

My changes attempt to fix this. This code seems a little bit dodgy since I don't really have a good big-picture view of how the code is supposed to work, but should be a superset of previous functionality. Basically I'm interpreting (emulating?) some of the relevant instructions (i32const, setlocal, getlocal) as we walk through the instructions within a function. It then looks at what the top of the stack is before the call function and uses that as the offset. Given that there shouldn't be any jumps between the i32const instruction and the call instruction, this should be sound logic.

I've run all of the examples in debug with wasm32-unknown-unknown and they seem to work. I don't necessarily expect this pull request to get merged in, but I'm at least providing it for reference if someone needs to get this working.