### PR TITLE
Support same-origin credentials in runtime wasm file fetch

### DIFF
--- a/src/wasm_runtime_standalone.js
+++ b/src/wasm_runtime_standalone.js
@@ -24,7 +24,7 @@ if( typeof Rust === "undefined" ) {
 
         return __initialize( mod, false );
     } else {
-        return fetch( "{{{wasm_filename}}}" )
+        return fetch( "{{{wasm_filename}}}", {credentials: "same-origin"} )
             .then( response => response.arrayBuffer() )
             .then( bytes => WebAssembly.compile( bytes ) )
             .then( mod => __initialize( mod, true ) );


### PR DESCRIPTION
I ran into a situation where I was using the output of a cargo-web build on a site requiring a cookie-based session.  More specifically, I was developing with cargo-web on an AWS Cloud9 cloud-hosted development environment.  The dev environment offers a URL through which you can browse your app, but they use a cookie to restrict access through that URL to the same browser running the editor session.  This provides similar functionality to being able to `cargo web start` on a local development box and look at the app while under development, but provides some modicum of security, so that no one but the developer can browse the app under development, even though the dev box is cloud-hosted.

When I ran `cargo web start --port 8080`, my browser was able to download the auto-generated index.html and the .js file, but suffered an error 499 when requesting the .wasm file.  It turns out the error was caused by the runtime .js not sending the required cookie when requesting the .wasm file.  Adding {credentials: "same-origin"} allows the fetch request to pass the session cookie header such that the .wasm file can be retrieved successfully.

I admit, this is a ridiculously niche circumstance, so I was a little concerned about submitting a PR for it.  But I couldn't think of a case under which having same origin credentials set for the fetch would actually do harm, so... humbly submitted for your consideration.