### PR TITLE
Return content of /index.html instead of 404

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -311,6 +311,13 @@ impl Project {
         }))
     }
 
+    pub fn index_on_404(&self) -> bool {
+        self.main_config
+            .as_ref()
+            .map(|config: &Config| config.index_on_404 )
+            .unwrap_or(false)
+    }
+
     fn used_packages( &self, profile: Profile ) -> Vec< &CargoPackage > {
         let main_package = self.package();
         let mut packages = self.project.used_packages(

--- a/src/build.rs
+++ b/src/build.rs
@@ -311,11 +311,11 @@ impl Project {
         }))
     }
 
-    pub fn index_on_404(&self) -> bool {
+    pub fn path_404(&self) -> Option<String> {
         self.main_config
             .as_ref()
-            .map(|config: &Config| config.index_on_404 )
-            .unwrap_or(false)
+            .map(|config: &Config| config.path_404.clone() )
+            .unwrap_or(None)
     }
 
     fn used_packages( &self, profile: Profile ) -> Vec< &CargoPackage > {

--- a/src/cmd_start.rs
+++ b/src/cmd_start.rs
@@ -263,7 +263,7 @@ pub fn command_start< 'a >( matches: &clap::ArgMatches< 'a > ) -> Result< (), Er
     let build_args = BuildArgs::new( matches )?;
     let project = build_args.load_project()?;
 
-    let path_404: Option<String> = project.path_404();
+    let path_404 = project.path_404();
 
     let last_build = {
         let target = select_target( &project )?;
@@ -296,7 +296,6 @@ pub fn command_start< 'a >( matches: &clap::ArgMatches< 'a > ) -> Result< (), Er
         let mut artifact = last_build.deployment.get_by_url( &path );
         if artifact.is_none() {
             if let Some( ref not_found_path ) = path_404 {
-                println!("Artifact could not be found, but should try to get user specified path instead");
                 artifact = last_build.deployment.get_by_url( &not_found_path )
             }
         }

--- a/src/cmd_start.rs
+++ b/src/cmd_start.rs
@@ -296,7 +296,7 @@ pub fn command_start< 'a >( matches: &clap::ArgMatches< 'a > ) -> Result< (), Er
         let mut artifact = last_build.deployment.get_by_url( &path );
         if artifact.is_none() {
             if let Some( ref not_found_path ) = path_404 {
-                debug!( "{} not found; serving {} instead", path, path_404 );
+                debug!( "{} not found; serving {} instead", path, not_found_path );
                 artifact = last_build.deployment.get_by_url( &not_found_path )
             }
         }

--- a/src/cmd_start.rs
+++ b/src/cmd_start.rs
@@ -296,6 +296,7 @@ pub fn command_start< 'a >( matches: &clap::ArgMatches< 'a > ) -> Result< (), Er
         let mut artifact = last_build.deployment.get_by_url( &path );
         if artifact.is_none() {
             if let Some( ref not_found_path ) = path_404 {
+                debug!( "{} not found; serving {} instead", path, path_404 );
                 artifact = last_build.deployment.get_by_url( &not_found_path )
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,8 +43,8 @@ pub struct Config {
     pub minimum_cargo_web_version: Option< Version >,
     pub per_target: HashMap< Backend, PerTargetConfig >,
     pub default_target: Option< Backend >,
-    /// Serve index.html instead of 404 when a file can not be found.
-    pub index_on_404: bool
+    /// Serve the file at the provided path instead of 404 when a file can not be found.
+    pub path_404: Option<String>
 }
 
 impl Config {
@@ -252,8 +252,9 @@ impl Config {
                                 }
                             }
                         },
-                        "index-on-404" => {
-                            config.index_on_404 = toplevel_value.try_into().map_err( |_| format!( "{}: 'index-on-404' is not a bool", config.source() ) )?;
+                        "404-path" => {
+                            let path_404: String = toplevel_value.try_into().map_err( |_| format!( "{}: '404-path' is not a string", config.source() ) ) ?;
+                            config.path_404 = Some(path_404);
                         }
                         toplevel_key => {
                             warnings.push( Warning::UnknownKey( toplevel_key.into() ) );

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,7 +42,9 @@ pub struct Config {
 
     pub minimum_cargo_web_version: Option< Version >,
     pub per_target: HashMap< Backend, PerTargetConfig >,
-    pub default_target: Option< Backend >
+    pub default_target: Option< Backend >,
+    /// Serve index.html instead of 404 when a file can not be found.
+    pub index_on_404: bool
 }
 
 impl Config {
@@ -250,6 +252,9 @@ impl Config {
                                 }
                             }
                         },
+                        "index-on-404" => {
+                            config.index_on_404 = toplevel_value.try_into().map_err( |_| format!( "{}: 'index-on-404' is not a bool", config.source() ) )?;
+                        }
                         toplevel_key => {
                             warnings.push( Warning::UnknownKey( toplevel_key.into() ) );
                         }

--- a/src/deployment.rs
+++ b/src/deployment.rs
@@ -42,7 +42,7 @@ const DEFAULT_INDEX_HTML_TEMPLATE: &'static str = r#"
     </script>
 </head>
 <body>
-    <script src="{{{js_url}}}"></script>
+    <script src="/{{{js_url}}}"></script>
 </body>
 </html>
 "#;

--- a/src/wasm_runtime_standalone.js
+++ b/src/wasm_runtime_standalone.js
@@ -19,13 +19,13 @@ if( typeof Rust === "undefined" ) {
         if( typeof window === "undefined" && typeof process === "object" ) {
             var fs = require( "fs" );
             var path = require( "path" );
-            var wasm_path = path.join( __dirname, "{{{wasm_filename}}}" );
+            var wasm_path = path.join( __dirname, "/{{{wasm_filename}}}" );
             var buffer = fs.readFileSync( wasm_path );
             var mod = new WebAssembly.Module( buffer );
             var wasm_instance = new WebAssembly.Instance( mod, instance.imports );
             return instance.initialize( wasm_instance );
         } else {
-            return fetch( "{{{wasm_filename}}}", {credentials: "same-origin"} )
+            return fetch( "/{{{wasm_filename}}}", {credentials: "same-origin"} )
                 .then( function( response ) { return response.arrayBuffer(); } )
                 .then( function( bytes ) { return WebAssembly.compile( bytes ); } )
                 .then( function( mod ) { return WebAssembly.instantiate( mod, instance.imports ) } )


### PR DESCRIPTION
The PR that implements the feature request detailed in https://github.com/koute/cargo-web/issues/100.

I don't think it is exactly clean enough to merge in its current state, but I have tested it and observed that it worked as intended, returning the index.html file instead of a 404 response when a requested file path doesn't exist.

This would allow a yew application with routing to return to a routed page when a page refresh is performed, improving developer ergonomics.