### PR TITLE
[test_chromium] fix 404 on /js/foo.wasm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ test-crates/*/Cargo.lock
 integration-tests/target
 integration-tests/Cargo.lock
 rls
+/.idea
+/*.iml

--- a/src/test_chromium.rs
+++ b/src/test_chromium.rs
@@ -91,7 +91,7 @@ pub fn test_in_chromium(
                 response_from_data( "application/javascript", data.into_bytes() )
             } else {
                 match *server_wasm_url.lock().unwrap() {
-                    Some( ref server_wasm_url ) if path == *server_wasm_url => {
+                    Some( ref server_wasm_url ) if path.ends_with(server_wasm_url) => {
                         let data = server_app_wasm.lock().unwrap().as_ref().unwrap().clone();
                         response_from_data( "application/wasm", data )
                     },


### PR DESCRIPTION
When running tests in Chrome, `/js/app.js` was trying to request `/js/foo.wasm` while the server expected `/foo.wasm`. Looking at `app.js`, it looks like heuristics are used to set the prefix `scriptDirectory`.

This PR makes us a little more robust to future changes and env differences, since I don't think we care too much about matching exactly the logic there.