### PR TITLE
Sorting __extjs_ in the compiled output.

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -100,7 +100,10 @@ pub fn process_wasm_file< P: AsRef< Path > + ?Sized >( runtime: RuntimeKind, bui
 
     parity_wasm::serialize_to_file( path, module ).unwrap();
 
-    let all_snippets: Vec< _ > = snippets.into_iter().chain( intrinsics.into_iter() ).collect();
+    let mut all_snippets: Vec< _ > = snippets.into_iter().chain( intrinsics.into_iter() ).collect();
+
+    all_snippets.sort_by( |a, b| a.name.cmp( &b.name ) );
+
     let js = wasm_runtime::generate_js( runtime, main_symbol, path, prepend_js, &all_snippets, &exports );
     let mut fp = File::create( &js_path ).unwrap();
     fp.write_all( js.as_bytes() ).unwrap();

--- a/src/wasm_inline_js.rs
+++ b/src/wasm_inline_js.rs
@@ -135,9 +135,13 @@ pub fn process_and_extract( ctx: &mut Context ) -> Vec< JsSnippet > {
                 offset
             };
 
-            snippet_index_by_offset.insert( offset, snippets.len() );
-            snippet_index_by_hash.insert( code_hash, snippets.len() );
-            snippets.push( snippet );
+            let index = snippets.binary_search_by( |x| {
+                x.name.cmp( &snippet.name )
+            } ).unwrap_err();
+
+            snippet_index_by_offset.insert( offset, index );
+            snippet_index_by_hash.insert( code_hash, index );
+            snippets.insert( index, snippet );
         }
     }
 


### PR DESCRIPTION
I noticed that when generating `__extjs_` snippets, they seem to appear in a random order.

Since I am checking in the compiled code into git, that causes huge git diffs (even if the code hasn't changed at all), since the order of the snippets gets rearranged.

This PR fixes it so that it sorts the snippets, causing them to appear in a stable order.

----

I'm not familiar with the cargo-web code, so I might be missing some areas which also need to be changed.

For example, does `ctx.js_snippets` also need to be in sorted order?