### PR TITLE
Adding in new --runtime web-extension feature

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -166,6 +166,7 @@ impl BuildArgs {
             match runtime {
                 "standalone" => RuntimeKind::Standalone,
                 "library-es6" => RuntimeKind::LibraryEs6,
+                "web-extension" => RuntimeKind::WebExtension,
                 "experimental-only-loader" => RuntimeKind::OnlyLoader,
                 _ => unreachable!( "Unknown runtime: {:?}", runtime )
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,8 +249,8 @@ fn main() {
                     .long( "runtime" )
                     .takes_value( true )
                     .value_name( "RUNTIME" )
-                    .help( "Selects the type of JavaScript runtime which will be generated; valid only for the `wasm32-unknown-unknown` target [possible values: standalone, library-es6]" )
-                    .possible_values( &["standalone", "library-es6", "experimental-only-loader"] )
+                    .help( "Selects the type of JavaScript runtime which will be generated; valid only for the `wasm32-unknown-unknown` target [possible values: standalone, library-es6, web-extension]" )
+                    .possible_values( &["standalone", "library-es6", "web-extension", "experimental-only-loader"] )
                     .default_value_if(
                         "target", Some( "wasm32-unknown-unknown" ),
                         "standalone"

--- a/src/wasm_runtime.rs
+++ b/src/wasm_runtime.rs
@@ -13,6 +13,7 @@ use wasm_js_export::{JsExport, TypeMetadata};
 pub enum RuntimeKind {
     Standalone,
     LibraryEs6,
+    WebExtension,
     OnlyLoader
 }
 
@@ -63,6 +64,7 @@ static FACTORY_TEMPLATE: &str = include_str!( "wasm_runtime_factory.js" );
 static ONLY_LOADER_TEMPLATE: &str = include_str!( "wasm_runtime_only_loader.js" );
 static STANDALONE_TEMPLATE: &str = include_str!( "wasm_runtime_standalone.js" );
 static LIBRARY_ES6_TEMPLATE: &str = include_str!( "wasm_runtime_library_es6.js" );
+static WEB_EXTENSION_TEMPLATE: &str = include_str!( "wasm_runtime_web_extension.js" );
 
 fn join< T: Display, I: IntoIterator< Item = T > >( separator: &str, iter: I ) -> String {
     let mut output = String::new();
@@ -155,6 +157,9 @@ pub fn generate_js( runtime: RuntimeKind, main_symbol: Option< String >, wasm_pa
         },
         RuntimeKind::LibraryEs6 => {
             handlebars.render_template( LIBRARY_ES6_TEMPLATE, &template_data ).unwrap()
+        },
+        RuntimeKind::WebExtension => {
+            handlebars.render_template( WEB_EXTENSION_TEMPLATE, &template_data ).unwrap()
         },
         RuntimeKind::OnlyLoader => {
             // TODO: Get rid of this.

--- a/src/wasm_runtime_web_extension.js
+++ b/src/wasm_runtime_web_extension.js
@@ -1,0 +1,24 @@
+"use strict";
+
+if( typeof Rust === "undefined" ) {
+    var Rust = {};
+}
+
+Rust.{{{module_name}}} = (function( module_factory ) {
+    var instance = module_factory();
+
+    var getURL = ( typeof browser === "object" && browser !== null
+        ? browser.runtime.getURL
+        : chrome.runtime.getURL );
+
+    return WebAssembly.instantiateStreaming( fetch( getURL( "{{{wasm_filename}}}" ), {credentials: "same-origin"} ), instance.imports )
+        .then( function( result ) {
+            var exports = instance.initialize( result.instance );
+            console.log( "Finished loading Rust wasm module '{{{module_name}}}'" );
+            return exports;
+        })
+        .catch( function( error ) {
+            console.log( "Error loading Rust wasm module '{{{module_name}}}':", error );
+            throw error;
+        });
+}( {{{factory}}} ));


### PR DESCRIPTION
Since it's specific for web extensions, the runtime is much smaller (it doesn't need Node support, or `instantiateStreaming` fallbacks, or UMD).

I didn't see any tests for the other runtime options, so I didn't add any.