### PR TITLE
Make sure we make the right js file serve under the js_name route

### DIFF
--- a/src/deployment.rs
+++ b/src/deployment.rs
@@ -113,9 +113,9 @@ impl Deployment {
 
         let mut routes = Vec::new();
         for path in result.artifacts() {
-            let (is_js, key) = match path.extension() {
-                Some( ext ) if ext == "js" => (true, js_name.clone()),
-                Some( ext ) if ext == "wasm" => (false, path.file_name().unwrap().to_string_lossy().into_owned()),
+            let (is_js, key) = match (path.file_stem(), path.extension()) {
+                (Some( stem ), Some( ext )) if stem == target.name.as_str() && ext == "js" => (true, js_name.clone()),
+                (_, Some( ext )) if ext == "wasm" => (false, path.file_name().unwrap().to_string_lossy().into_owned()),
                 _ => continue
             };
 


### PR DESCRIPTION
A quick fix for #176, where if a dependency generates a wasm its generated js can take priority over the js generated for the project's main wasm.