### PR TITLE
Improved detection if js runtime is run by node.js

### DIFF
--- a/src/wasm_runtime_standalone.js
+++ b/src/wasm_runtime_standalone.js
@@ -16,7 +16,7 @@ if( typeof Rust === "undefined" ) {
     return (function( module_factory ) {
         var instance = module_factory();
 
-        if( typeof window === "undefined" && typeof process === "object" ) {
+        if( typeof process === "object" && typeof process.versions === "object" && typeof process.versions.node === "string" ) {
             var fs = require( "fs" );
             var path = require( "path" );
             var wasm_path = path.join( __dirname, "{{{wasm_filename}}}" );


### PR DESCRIPTION
As described in #178 this fixes a bug where the js runtime erroneously believes it is run by a browser and not node.js.