### PR TITLE
fix --no-default-features flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,7 +333,7 @@ struct Build {
     #[structopt(long, group = "build_features")]
     pub all_features: bool,
     /// Do not build the `default` feature
-    #[structopt(long, group = "build_features")]
+    #[structopt(long)]
     pub no_default_features: bool,
     /// Won't try to download Emscripten; will always use the system one
     #[structopt(long)]


### PR DESCRIPTION
Right now --no-default-features can't be used together with --features cause they are in the same group (build_features) making them exclusive

This is not how plain cargo works which allows this flags to be used together

This simply removes no_default_features from the build_features group since I don't think there's a way to say that two options in the same group are not exclusive in StructOpt