### PR TITLE
Fetch WASM module from server root

### DIFF
--- a/src/wasm_runtime_standalone.js
+++ b/src/wasm_runtime_standalone.js
@@ -25,7 +25,7 @@ if( typeof Rust === "undefined" ) {
             var wasm_instance = new WebAssembly.Instance( mod, instance.imports );
             return instance.initialize( wasm_instance );
         } else {
-            var file = fetch( "{{{wasm_filename}}}", {credentials: "same-origin"} );
+            var file = fetch( "/{{{wasm_filename}}}", {credentials: "same-origin"} );
 
             var wasm_instance = ( typeof WebAssembly.instantiateStreaming === "function"
                 ? WebAssembly.instantiateStreaming( file, instance.imports )


### PR DESCRIPTION
When using a frontend framework such as yew, client-side routing
necessitates that the wasm bundle be requested from an absolute URL
instead of a relative URL.