### PR TITLE
In webbrowser load WASM from same folder as JS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-web"
-version = "0.6.26"
+version = "0.6.27"
 authors = ["Jan Bujak <j@exia.io>"]
 repository = "https://github.com/koute/cargo-web"
 homepage = "https://github.com/koute/cargo-web"

--- a/src/wasm_runtime_standalone.js
+++ b/src/wasm_runtime_standalone.js
@@ -25,7 +25,11 @@ if( typeof Rust === "undefined" ) {
             var wasm_instance = new WebAssembly.Instance( mod, instance.imports );
             return instance.initialize( wasm_instance );
         } else {
-            var file = fetch( "{{{wasm_filename}}}", {credentials: "same-origin"} );
+            var jsurl = new URL( document.querySelector( 'script[src$="{{{module_name}}}.js"]' ).src );
+            var jspath = jsurl.pathname;
+            var dotpos = jspath.lastIndexOf( "." );
+            var wasmpath = jspath.substr( 0, dotpos ) + ".wasm";
+            var file = fetch( wasmpath, {credentials: "same-origin"} );
 
             var wasm_instance = ( typeof WebAssembly.instantiateStreaming === "function"
                 ? WebAssembly.instantiateStreaming( file, instance.imports )


### PR DESCRIPTION
This pull request addresses issue #131 "Question: how to specify the wasm path in the generated js file?".

In the current version it is assumed (when running inside a webbrowser)
that the WASM module is located in the default path, 
which is not always the case (in my case I have a webserver serving
a number of different WASM modules in different paths).

This modification to src/wasm_runtime_standalone.js will do for
the webbrowser case the same as it already does for the NodeJS case:
to get the URL for the javascript file that is then itself running, 
and then load the WASM module from the same directory.

The logic for getting the URL for the Javascript file I have
taken from this thread: https://stackoverflow.com/questions/3097644/can-code-in-a-javascript-file-know-its-own-domain-url .
Maybe there is now a better way to do this?
