### PR TITLE
Fix warnings

### DIFF
--- a/src/cargo_shim/mod.rs
+++ b/src/cargo_shim/mod.rs
@@ -250,23 +250,14 @@ pub enum Error {
 }
 
 
-impl error::Error for Error {
-    fn description( &self ) -> &str {
-        match *self {
-            Error::CannotLaunchCargo( _ ) => "cannot launch cargo",
-            Error::CargoFailed( _ ) => "cargo failed",
-            Error::CannotParseCargoOutput( _ ) => "cannot parse cargo output"
-        }
-    }
-}
+impl error::Error for Error {}
 
 impl fmt::Display for Error {
-    fn fmt( &self, formatter: &mut fmt::Formatter ) -> fmt::Result {
-        use std::error::Error as StdError;
+    fn fmt( &self, fmt: &mut fmt::Formatter ) -> fmt::Result {
         match *self {
-            Error::CannotLaunchCargo( ref err ) => write!( formatter, "{}: {}", self.description(), err ),
-            Error::CargoFailed( ref err ) => write!( formatter, "{}: {}", self.description(), err ),
-            Error::CannotParseCargoOutput( ref err ) => write!( formatter, "{}: {}", self.description(), err )
+            Error::CannotLaunchCargo( ref err ) => write!( fmt, "cannot launch cargo: {}", err ),
+            Error::CargoFailed( ref err ) => write!( fmt, "cargo failed: {}", err ),
+            Error::CannotParseCargoOutput( ref err ) => write!( fmt, "cannot parse cargo output: {}", err )
         }
     }
 }

--- a/src/cargo_shim/mod.rs
+++ b/src/cargo_shim/mod.rs
@@ -11,7 +11,6 @@ use std::thread;
 use std::str::{self, FromStr};
 use std::error;
 use std::fmt;
-use std::iter;
 
 use cargo_metadata;
 use serde_json;
@@ -434,14 +433,6 @@ impl CargoProject {
         }
 
         Ok( project )
-    }
-
-    pub fn default_package( &self ) -> Option< &CargoPackage > {
-        self.packages.iter().find( |package| package.is_default )
-    }
-
-    pub fn used_packages( &self, triplet: &str, main_package: &CargoPackage, profile: Profile ) -> Vec< &CargoPackage > {
-        self.used_packages_with_rustflags( triplet, main_package, profile, iter::empty() )
     }
 
     pub fn used_packages_with_rustflags< 'a, I >(
@@ -912,7 +903,7 @@ impl BuildConfig {
             }
         }
 
-        for mut artifact in artifacts {
+        for artifact in artifacts {
             if artifact.filenames.is_empty() {
                 continue;
             }

--- a/src/chrome_devtools.rs
+++ b/src/chrome_devtools.rs
@@ -19,20 +19,13 @@ pub enum ConnectionError {
     WebSocketError( WebSocketError )
 }
 
-impl Error for ConnectionError {
-    fn description( &self ) -> &str {
-        match *self {
-            ConnectionError::FailedToFetchUrl( _ ) => "failed to fetch websocket debugger URL",
-            ConnectionError::WebSocketError( _ ) => "web socket error"
-        }
-    }
-}
+impl Error for ConnectionError {}
 
 impl fmt::Display for ConnectionError {
     fn fmt( &self, fmt: &mut fmt::Formatter ) -> fmt::Result {
         match *self {
-            ConnectionError::FailedToFetchUrl( ref message ) => write!( fmt, "{}: {}", self.description(), message ),
-            ConnectionError::WebSocketError( ref message ) => write!( fmt, "{}: {}", self.description(), message )
+            ConnectionError::FailedToFetchUrl( ref message ) => write!( fmt, "failed to fetch websocket debugger URL: {}", message ),
+            ConnectionError::WebSocketError( ref message ) => write!( fmt, "web socket error: {}", message )
         }
     }
 }
@@ -55,20 +48,13 @@ pub enum CommunicationError {
     Recv( WebSocketError )
 }
 
-impl Error for CommunicationError {
-    fn description( &self ) -> &str {
-        match *self {
-            CommunicationError::Send( _ ) => "error while sending web socket message",
-            CommunicationError::Recv( _ ) => "error while receiving web socket message"
-        }
-    }
-}
+impl Error for CommunicationError {}
 
 impl fmt::Display for CommunicationError {
     fn fmt( &self, fmt: &mut fmt::Formatter ) -> fmt::Result {
         match *self {
-            CommunicationError::Send( ref message ) => write!( fmt, "{}: {}", self.description(), message ),
-            CommunicationError::Recv( ref message ) => write!( fmt, "{}: {}", self.description(), message )
+            CommunicationError::Send( ref message ) => write!( fmt, "error while sending web socket message: {}", message ),
+            CommunicationError::Recv( ref message ) => write!( fmt, "error while receiving web socket message: {}", message )
         }
     }
 }
@@ -81,24 +67,15 @@ pub enum ReplyError {
     CommunicationError( CommunicationError )
 }
 
-impl Error for ReplyError {
-    fn description( &self ) -> &str {
-        match *self {
-            ReplyError::Timeout => "timeout while waiting for reply",
-            ReplyError::MalformedMessage( _ ) => "received malformed message",
-            ReplyError::MalformedJson( _ ) => "received malformed JSON",
-            ReplyError::CommunicationError( _ ) => "communication error"
-        }
-    }
-}
+impl Error for ReplyError {}
 
 impl fmt::Display for ReplyError {
     fn fmt( &self, fmt: &mut fmt::Formatter ) -> fmt::Result {
         match *self {
-            ReplyError::Timeout => write!( fmt, "{}", self.description() ),
-            ReplyError::MalformedMessage( ref error ) => write!( fmt, "{}: {}", self.description(), error ),
-            ReplyError::MalformedJson( ref error ) => write!( fmt, "{}: {}", self.description(), error ),
-            ReplyError::CommunicationError( ref error ) => write!( fmt, "{}: {}", self.description(), error )
+            ReplyError::Timeout => write!( fmt, "timeout while waiting for reply" ),
+            ReplyError::MalformedMessage( ref error ) => write!( fmt, "received malformed message: {}", error ),
+            ReplyError::MalformedJson( ref error ) => write!( fmt, "received malformed JSON: {}", error ),
+            ReplyError::CommunicationError( ref error ) => write!( fmt, "communication error: {}", error )
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,26 +23,7 @@ pub enum Error {
     Other( Box< error::Error > )
 }
 
-impl error::Error for Error {
-    fn description( &self ) -> &str {
-        match *self {
-            Error::ConfigurationError( ref message ) => &message,
-            Error::EnvironmentError( ref message ) => &message,
-            Error::RuntimeError( ref message, _ ) => &message,
-            Error::BuildError => "build failed",
-            Error::NoDefaultPackage => "no default package; you can specify a crate to use with the `-p` argument",
-            Error::EmscriptenNotAvailable => "prepackaged Emscripten is not available for this platform",
-            Error::CargoShimError( ref error ) => error.description(),
-            Error::CannotLoadFile( .. ) => "cannot load file",
-            Error::CannotRemoveDirectory( .. ) => "cannot remove directory",
-            Error::CannotRemoveFile( .. ) => "cannot remove file",
-            Error::CannotCreateFile( .. ) => "cannot create file",
-            Error::CannotWriteToFile( .. ) => "cannot write to file",
-            Error::CannotCopyFile( .. ) => "cannot copy file",
-            Error::Other( ref error ) => error.description()
-        }
-    }
-}
+impl error::Error for Error {}
 
 impl From< cargo_shim::Error > for Error {
     fn from( err: cargo_shim::Error ) -> Self {
@@ -69,20 +50,23 @@ impl< 'a > From< &'a str > for Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt( &self, formatter: &mut fmt::Formatter ) -> fmt::Result {
-        use std::error::Error as StdError;
-        match self {
-            &Error::RuntimeError( _, ref inner ) => write!( formatter, "{}: {}", self.description(), inner ),
-            &Error::CargoShimError( cargo_shim::Error::CargoFailed( ref message ) ) => write!( formatter, "{}", message ),
-            &Error::CargoShimError( ref inner ) => write!( formatter, "{}", inner ),
-            &Error::CannotLoadFile( ref path, ref inner ) => write!( formatter, "cannot load file {:?}: {}", path, inner ),
-            &Error::CannotRemoveDirectory( ref path, ref inner ) => write!( formatter, "cannot remove directory {:?}: {}", path, inner ),
-            &Error::CannotRemoveFile( ref path, ref inner ) => write!( formatter, "cannot remove file {:?}: {}", path, inner ),
-            &Error::CannotCreateFile( ref path, ref inner ) => write!( formatter, "cannot create file {:?}: {}", path, inner ),
-            &Error::CannotWriteToFile( ref path, ref inner ) => write!( formatter, "cannot write to file {:?}: {}", path, inner ),
-            &Error::CannotCopyFile( ref src_path, ref dst_path, ref inner ) => write!( formatter, "cannot copy file from {:?} to {:?}: {}", src_path, dst_path, inner ),
-            &Error::Other( ref inner ) => write!( formatter, "{}", inner ),
-            _ => write!( formatter, "{}", self.description() )
+    fn fmt( &self, fmt: &mut fmt::Formatter ) -> fmt::Result {
+        match *self {
+            Error::ConfigurationError( ref message ) => write!( fmt, "{}", message ),
+            Error::EnvironmentError( ref message ) => write!( fmt, "{}", message ),
+            Error::RuntimeError( ref message, ref inner ) => write!( fmt, "{}: {}", message, inner ),
+            Error::BuildError => write!( fmt, "build failed" ),
+            Error::NoDefaultPackage => write!( fmt, "no default package; you can specify a crate to use with the `-p` argument" ),
+            Error::EmscriptenNotAvailable => write!( fmt, "prepackaged Emscripten is not available for this platform" ),
+            Error::CargoShimError( cargo_shim::Error::CargoFailed( ref message ) ) => write!( fmt, "{}", message ),
+            Error::CargoShimError( ref inner ) => write!( fmt, "{}", inner ),
+            Error::CannotLoadFile( ref path, ref inner ) => write!( fmt, "cannot load file {:?}: {}", path, inner ),
+            Error::CannotRemoveDirectory( ref path, ref inner ) => write!( fmt, "cannot remove directory {:?}: {}", path, inner ),
+            Error::CannotRemoveFile( ref path, ref inner ) => write!( fmt, "cannot remove file {:?}: {}", path, inner ),
+            Error::CannotCreateFile( ref path, ref inner ) => write!( fmt, "cannot create file {:?}: {}", path, inner ),
+            Error::CannotWriteToFile( ref path, ref inner ) => write!( fmt, "cannot write to file {:?}: {}", path, inner ),
+            Error::CannotCopyFile( ref src_path, ref dst_path, ref inner ) => write!( fmt, "cannot copy file from {:?} to {:?}: {}", src_path, dst_path, inner ),
+            Error::Other( ref inner ) => write!( fmt, "{}", inner ),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,7 +9,7 @@ use cargo_shim;
 pub enum Error {
     ConfigurationError( String ),
     EnvironmentError( String ),
-    RuntimeError( String, Box< error::Error > ),
+    RuntimeError( String, Box< dyn error::Error > ),
     BuildError,
     NoDefaultPackage,
     EmscriptenNotAvailable,
@@ -20,7 +20,7 @@ pub enum Error {
     CannotCreateFile( PathBuf, io::Error ),
     CannotWriteToFile( PathBuf, io::Error ),
     CannotCopyFile( PathBuf, PathBuf, io::Error ),
-    Other( Box< error::Error > )
+    Other( Box< dyn error::Error > )
 }
 
 impl error::Error for Error {}
@@ -31,8 +31,8 @@ impl From< cargo_shim::Error > for Error {
     }
 }
 
-impl From< Box< error::Error > > for Error {
-    fn from( err: Box< error::Error > ) -> Self {
+impl From< Box< dyn error::Error > > for Error {
+    fn from( err: Box< dyn error::Error > ) -> Self {
         Error::Other( err )
     }
 }

--- a/src/http_utils.rs
+++ b/src/http_utils.rs
@@ -50,9 +50,9 @@ impl From< Mmap > for Body {
     }
 }
 
-pub type ResponseFuture = Box< Future< Item = Response< Body >, Error = hyper::Error > + Send >;
-pub type FnHandler = Box< Fn( Request< hyper::Body > ) -> ResponseFuture + Send + Sync >;
-pub type ServiceFuture = Box< Future< Item = SimpleService, Error = hyper::Error > + Send >;
+pub type ResponseFuture = Box< dyn Future< Item = Response< Body >, Error = hyper::Error > + Send >;
+pub type FnHandler = Box< dyn Fn( Request< hyper::Body > ) -> ResponseFuture + Send + Sync >;
+pub type ServiceFuture = Box< dyn Future< Item = SimpleService, Error = hyper::Error > + Send >;
 
 pub struct SimpleService {
     handler: Arc< FnHandler >

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::fs::{self, File};
-use std::io::{self, Read, Write};
+use std::io::Write;
 
 use parity_wasm;
 use cargo_shim::BuildConfig;

--- a/src/wasm_context.rs
+++ b/src/wasm_context.rs
@@ -538,7 +538,7 @@ impl Context {
                         next_global_index += 1;
                     }
                 },
-                pw::Section::Export( mut section ) => {
+                pw::Section::Export( section ) => {
                     exports_sections.push( section );
                 },
                 pw::Section::Start( function_index ) => {
@@ -576,7 +576,7 @@ impl Context {
                         ctx.next_function_index += 1;
                     }
                 },
-                pw::Section::Function( mut section ) => {
+                pw::Section::Function( section ) => {
                     // We'll convert it later since those can appear before
                     // the functions themselves are actually defined.
                     function_sections.push( section );


### PR DESCRIPTION
`std::error::Error` has its `description()` function deprecated since Rust 1.41.0.

The rest were unused imports or functions, missing `dyn` or extra `mut`.