### PR TITLE
cargo_shim: Correctly compute path for wasm32-unknown-emscripten

### DIFF
--- a/src/cargo_shim/mod.rs
+++ b/src/cargo_shim/mod.rs
@@ -899,10 +899,10 @@ impl BuildConfig {
                             let wasm_path = {
                                 let main_artifact = Path::new( &artifacts[ artifact_index ].filenames[ filename_index ] );
                                 let filename = main_artifact.file_name().unwrap();
-                                main_artifact.parent().unwrap().join( "deps" ).join( filename ).with_extension( "wasm" )
+                                main_artifact.parent().unwrap().join( filename ).with_extension( "wasm" )
                             };
 
-                            assert!( wasm_path.exists(), "internal error: wasm doesn't exist where I expected it to be" );
+                            assert!(wasm_path.exists(), "internal error: wasm doesn't exist at {:?}", wasm_path);
                             artifacts[ artifact_index ].filenames.push( wasm_path.to_str().unwrap().to_owned() );
                             debug!( "Found `.wasm` test artifact: {:?}", wasm_path );
                         }


### PR DESCRIPTION
The [`getrandom` crate](https://github.com/rust-random/getrandom) currently builds (but does not run) tests for
`wasm32-unknown-emscripten`. Recently, cargo started putting artifacts in
a different location, causing cargo-web to break when running `cargo web test`.

This change correctly looks up the path for .wasm artifacts.

CC: https://github.com/rust-random/getrandom/issues/140

Signed-off-by: Joe Richey <joerichey@google.com>