### PR TITLE
Filter empty features from command line.

### DIFF
--- a/src/cargo_shim/mod.rs
+++ b/src/cargo_shim/mod.rs
@@ -299,6 +299,12 @@ impl CargoProject {
             command.arg( "--all-features" );
         }
 
+        let features = features
+            .iter()
+            .filter(|f| !f.is_empty())
+            .cloned()
+            .collect::<Vec<_>>();
+
         if !features.is_empty() {
             command.arg( "--features" );
             command.arg( &features.join( " " ) );
@@ -697,8 +703,13 @@ impl BuildConfig {
         if self.enable_all_features {
             command.arg( "--all-features" );
         }
+        
+        let features = self.features
+            .iter()
+            .filter(|f| !f.is_empty())
+            .collect::<Vec<_>>();
 
-        if !self.features.is_empty() {
+        if !features.is_empty() {
             command.arg( "--features" );
             command.arg( &self.features.join( " " ) );
         }


### PR DESCRIPTION
This change filters out empty features from the default command line options.

This change is needed to support cargo workspaces where no features can be specified as it triggers an error from cargo. It appears that the standard behavior for the features flag is to be a Vec<String> that contains one empty item. I was not able to get structopt to parse this in a sensible way given a default command line with no features specified.