### PR TITLE
Set 'id' attribute of canvas element in auto-generated index.html

### DIFF
--- a/src/deployment.rs
+++ b/src/deployment.rs
@@ -34,6 +34,7 @@ const DEFAULT_INDEX_HTML_TEMPLATE: &'static str = r#"<!DOCTYPE html>
                 }
 
                 var canvas = document.createElement( 'canvas' );
+                canvas.setAttribute('id', 'canvas');
                 document.querySelector( 'body' ).appendChild( canvas );
                 __cargo_web.canvas = canvas;
 


### PR DESCRIPTION
This fixes a problem I experienced where the out-of-the-box generated index.html is not compatible with Emscripten's way of identifying the canvas element for the purpose of for example SDL2.

As seen here: https://emscripten.org/docs/api_reference/html5.h.html#registration-functions

```#canvas: If building with legacy option -s DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=0 (not recommended), the event listener is applied to the Emscripten default WebGL canvas element. If building with the option -s DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1 (default), #canvas is interpreted as a CSS query selector: “the first element with CSS ID ‘canvas’”.```

The CSS ID 'canvas' is needed on the canvas element with the default build option of emscripten. Perhaps this is something that has changed recently. With the fix in this pull request, it works out of the box for me.