### PR TITLE
Fix compiler error

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -87,7 +87,7 @@ pub fn find_cmd< 'a >( cmds: &[ &'a str ] ) -> Option< &'a str > {
 
 pub fn unpack< I: AsRef< Path >, O: AsRef< Path > >( input_path: I, output_path: O ) -> Result< (), Box< io::Error > > {
     let output_path = output_path.as_ref();
-    let file = fs::File::open( input_path )?;
+    let file = File::open( input_path )?;
     let reader = BufReader::new( file );
     let decoder = gzip::Decoder::new( reader )?;
     let mut archive = tar::Archive::new( decoder );


### PR DESCRIPTION
When running `cargo build` on the current commit, I get this output.
[compiler.log](https://github.com/user-attachments/files/17215265/compiler.log)
When running `cargo clippy`, I get this output.
[clippy.log](https://github.com/user-attachments/files/17215276/clippy.log)

The relevant error is:
```
error: unnecessary qualification
  --> src/utils.rs:90:16
   |
90 |     let file = fs::File::open( input_path )?;
   |                ^^^^^^^^^^^^^^
   |
note: the lint level is defined here
  --> src/lib.rs:8:5
   |
8  |     unused_qualifications
   |     ^^^^^^^^^^^^^^^^^^^^^
help: remove the unnecessary path segments
   |
90 -     let file = fs::File::open( input_path )?;
90 +     let file = File::open( input_path )?;
   |
```
Applying said change results in a successful build, but there are still many warnings generated, but it builds, at least.